### PR TITLE
ED-601 - Added Pre/Post network activity notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,11 @@ Objective-C:
 ```
 
 ### Notifications
-In case you need to change your interface before we are doing a network request, you can subscribe to the `willMakeNetorkRequest` and `didFinishNetworkRequest` notification from the `YotiSDK` class
+In case you need to change your interface before we are doing a network request, you can subscribe to the `willMakeNetworkRequest` and `didFinishNetworkRequest` notification from the `YotiSDK` class
 
 Swift: 
 ```
-NotificationCenter.default.addObserver(forName: YotiSDK.willMakeNetorkRequest, object: nil, queue: nil) { (notification) in
+NotificationCenter.default.addObserver(forName: YotiSDK.willMakeNetworkRequest, object: nil, queue: nil) { (notification) in
     // Disable interface
 }
 ```
@@ -182,7 +182,7 @@ NotificationCenter.default.addObserver(forName: YotiSDK.didFinishNetworkRequest,
 
 Objective-C: 
 ```
-[NSNotificationCenter.defaultCenter addObserverForName:YotiSDK.willMakeNetorkRequest object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+[NSNotificationCenter.defaultCenter addObserverForName:YotiSDK.willMakeNetworkRequest object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
     // Disable interface
 }];
 ```

--- a/README.md
+++ b/README.md
@@ -164,6 +164,40 @@ Objective-C:
 [YotiSDK addScenario:scenario];
 ```
 
+### Notifications
+In case you need to change your interface before we are doing a network request, you can subscribe to the `willMakeNetorkRequest` and `didFinishNetworkRequest` notification from the `YotiSDK` class
+
+Swift: 
+```
+NotificationCenter.default.addObserver(forName: YotiSDK.willMakeNetorkRequest, object: nil, queue: nil) { (notification) in
+    // Disable interface
+}
+```
+
+```
+NotificationCenter.default.addObserver(forName: YotiSDK.didFinishNetworkRequest, object: nil, queue: nil) { (notification) in
+    // Re-enable interface
+}
+```
+
+Objective-C: 
+```
+[NSNotificationCenter.defaultCenter addObserverForName:YotiSDK.willMakeNetorkRequest object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+    // Disable interface
+}];
+```
+
+```
+[NSNotificationCenter.defaultCenter addObserverForName:YotiSDK.didFinishNetworkRequest object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+    // Re-enable interface
+}];
+```
+
+Note:
+`willMakeNetorkRequest` will be called twice if you set `isProcessed` to `false` in the `clientCompletion` block. The first time will be before openning the Yoti application and the second time will be after the Yoti Application re-open your application.
+
+`didFinishNetworkRequest` will only be called once whether the `isProcessed` is set to `true` or `false`. 
+
 ### Inter-app communication
 
 Yoti SDK would perform an app switch to Yoti app and back to your app to complete the sharing process, your application's `.plist` also need to handle this.

--- a/Sample/sdk-ios-swift/ViewController.swift
+++ b/Sample/sdk-ios-swift/ViewController.swift
@@ -57,13 +57,6 @@ class ViewController: UIViewController {
         catch {
             
         }
-        NotificationCenter.default.addObserver(forName: YotiSDK.willMakeNetorkRequest, object: nil, queue: nil) { (notification) in
-            print("+1")
-        }
-        NotificationCenter.default.addObserver(forName: YotiSDK.didFinishNetworkRequest, object: nil, queue: nil) { (notification) in
-            print("-1")
-        }
-
 
         // Do any additional setup after loading the view, typically from a nib.
     }

--- a/Sample/sdk-ios-swift/ViewController.swift
+++ b/Sample/sdk-ios-swift/ViewController.swift
@@ -57,8 +57,14 @@ class ViewController: UIViewController {
         catch {
             
         }
-        
-        
+        NotificationCenter.default.addObserver(forName: YotiSDK.willMakeNetorkRequest, object: nil, queue: nil) { (notification) in
+            print("+1")
+        }
+        NotificationCenter.default.addObserver(forName: YotiSDK.didFinishNetworkRequest, object: nil, queue: nil) { (notification) in
+            print("-1")
+        }
+
+
         // Do any additional setup after loading the view, typically from a nib.
     }
     

--- a/YotiButtonSDK/Kernel/Service/CallbackBackendService.swift
+++ b/YotiButtonSDK/Kernel/Service/CallbackBackendService.swift
@@ -10,13 +10,9 @@ import Foundation
 
 class CallbackBackendService: HTTPService, URLSessionDelegate {
     
-    var scenario: Scenario?
     lazy var urlSession = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         
-    func callbackBackend(scenario: Scenario, token: String) {
-        
-        self.scenario = scenario
-        let completion = scenario.backendCompletion
+    func callbackBackend(scenario: Scenario, token: String, completion: @escaping (Data?, Error?) -> Void) {
         
         guard let callbackBackendURL = scenario.callbackBackendURL else {
             completion(nil, GenericError.nilValue("callbackBackendURL"))

--- a/YotiButtonSDK/YotiSDK.swift
+++ b/YotiButtonSDK/YotiSDK.swift
@@ -13,6 +13,9 @@ import UIKit
 public class YotiSDK: NSObject {
 
     static let shared = YotiSDK()
+    @objc public static let didFinishNetworkRequest = Notification.Name("yoti.didFinishNetworkRequest")
+    @objc public static let willMakeNetorkRequest = Notification.Name("yoti.willMakeNetorkRequest")
+
     var kernel = KernelSDK.shared
     private var scenarios = [String: Scenario]()
     

--- a/YotiButtonSDK/YotiSDK.swift
+++ b/YotiButtonSDK/YotiSDK.swift
@@ -13,8 +13,8 @@ import UIKit
 public class YotiSDK: NSObject {
 
     static let shared = YotiSDK()
-    @objc public static let didFinishNetworkRequest = Notification.Name("yoti.didFinishNetworkRequest")
-    @objc public static let willMakeNetorkRequest = Notification.Name("yoti.willMakeNetorkRequest")
+    @objc public static let didFinishNetworkRequest = Notification.Name("com.yoti.didFinishNetworkRequest")
+    @objc public static let willMakeNetworkRequest = Notification.Name("com.yoti.willMakeNetworkRequest")
 
     var kernel = KernelSDK.shared
     private var scenarios = [String: Scenario]()


### PR DESCRIPTION
## Purpose
Adding notifications to the SDK to notify the the client Application that some network request will start and did finish.

## Approach
Added `willMakeNetworkRequest` and `didFinishNetworkRequest` (NS)Notifications

## Breaking changes
None
