### PR TITLE
[BUG] ED-903 Fixed Installation issue on device for sample app

### DIFF
--- a/Sample/sdk-ios-swift.xcodeproj/project.pbxproj
+++ b/Sample/sdk-ios-swift.xcodeproj/project.pbxproj
@@ -451,6 +451,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 6VUTP72GG4;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -471,6 +472,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 6VUTP72GG4;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",


### PR DESCRIPTION
## Purpose
The purpose is to be able to install the sample apps

## Approach
the issue with SDK V1 built is not installable, this is due to a settings in project config of the sample app
I have changed the config settings of the project.



## Scope of changes
Sample app.

## Checklist

- [ ] checkout the branch `feature/FixSampleAppInstallationIssue`

- [ ] Archive the app and make sure that you can install it on a development device.
