### PR TITLE
[Improvement] YM-13740: Migrate iOS Button SDK to Swift 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo contains the tools and step by step instructions so that your users ca
 ## Requirements
 - You will need to have the Yoti app on your phone
 - You will need to ensure the minimum version of the deployment target is 9.0 or above.
+- You will need Xcode 10.2 or above
 
 ## Installing the SDK
 
@@ -38,7 +39,7 @@ $ brew install carthage
 To integrate Yoti into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```
-github "getyoti/ios-sdk-button" ~> 1.0
+github "getyoti/ios-sdk-button" ~> 2.0
 ```
 
 This will allow you to type `carthage update ios-sdk-button` in your Terminal to fetch and build the latest version of the framework.
@@ -48,13 +49,35 @@ Drag the built `YotiButtonSDK.framework` into your Xcode project without copying
 
 Each time you want to fetch the dependency, you can type  `carthage bootstrap`.
 
+### CocoaPods
+
+[CocoaPods](https://cocoapods.org) is a dependency manager for Swift and Objective-C Cocoa projects.
+
+Using the default Ruby install can require you to use sudo when installing gems. Further installation instructions are in [the guides](https://guides.cocoapods.org/using/getting-started.html#getting-started).
+
+```
+$ sudo gem install cocoapods
+```
+
+To integrate Yoti into your Xcode project using Cocoapods, specify it in your `Podfile`:
+
+```
+pod 'yoti-sdk' ~> 2.0
+```
+
+Tip: CocoaPods provides a `pod init` command to create a Podfile with smart defaults. You should use it.
+
+Now you can install the dependencies in your project:
+
+```
+$ pod install
+```
+
+Make sure to always open the Xcode workspace instead of the project file when building your project.
+
 ### Drag & Drop (not recommended)
 
 You can also add the Yoti SDK by adding the project via a submodule and dragging the Yoti's project file into yours.
-
-### Pod
-
-We don't currently support Pod but it's coming soon.
 
 ## Configuration
 Before we start the configuration you have to add Yoti SDK as a build phase:

--- a/YotiButtonSDK.xcodeproj/project.pbxproj
+++ b/YotiButtonSDK.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Yoti Limited";
 				TargetAttributes = {
 					B43B0E0F1F22063800CD5E4E = {
@@ -291,7 +291,7 @@
 			};
 			buildConfigurationList = B43B0E0A1F22063800CD5E4E /* Build configuration list for PBXProject "YotiButtonSDK" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -374,6 +374,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -420,7 +421,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -465,6 +466,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -509,7 +511,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/YotiButtonSDK.xcodeproj/xcshareddata/xcschemes/YotiButtonSDK.xcscheme
+++ b/YotiButtonSDK.xcodeproj/xcshareddata/xcschemes/YotiButtonSDK.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YotiButtonSDK/Info.plist
+++ b/YotiButtonSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/YotiButtonSDK/YotiButton.swift
+++ b/YotiButtonSDK/YotiButton.swift
@@ -58,14 +58,14 @@ public class YotiButton: UIButton {
         styleSubviews()
     }
 
-    public override func setTitle(_ title: String?, for state: UIControlState) {
+    public override func setTitle(_ title: String?, for state: UIControl.State) {
         messageLabel.text = title
         messageLabel.sizeToFit()
         messageWidthConstraint?.constant = messageLabel.frame.width
 
     }
 
-    public override func setTitleColor(_ color: UIColor?, for state: UIControlState) {
+    public override func setTitleColor(_ color: UIColor?, for state: UIControl.State) {
         if let color = color {
             messageLabel.textColor = color
         }

--- a/YotiButtonSDK/YotiSDK.swift
+++ b/YotiButtonSDK/YotiSDK.swift
@@ -71,13 +71,13 @@ public class YotiSDK: NSObject {
 
     // MARK: - UIApplication Delegate
 
-    @objc public static func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
+    @objc public static func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         return shared.application(app, open: url, options: options)
     }
 
-    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
 
-        guard let bundleID = options[UIApplicationOpenURLOptionsKey.sourceApplication] as? String,
+        guard let bundleID = options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
                   bundleID == EnvironmentConfiguation.YotiApp.bundleID
         else {
             return false

--- a/yoti-sdk.podspec
+++ b/yoti-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "yoti-sdk"
-  s.version      = "1.1"
+  s.version      = "2.1"
   s.summary      = "A button SDK that uses Yoti app to complete the share"
 
   # This description is used to generate tags and improve search results.
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
 
   # s.platform     = :ios
   s.platform     = :ios, "9.0"
-  s.swift_version = '4.0'
+  s.swift_version = '5.0'
 
   #  When using multiple platforms
   # s.ios.deployment_target = "5.0"


### PR DESCRIPTION
## Purpose
Update the project to support to Swift 5 / Xcode 10.2

## Approach
- Update API usage with Swift 5
- Set targets' Swift Language Version as Swift 5 

## Breaking changes
We only support Xcode 10.2 or above