### PR TITLE
[Task] YM-16123: Remove Yoti App check on iOS 13 due to new privacy policy

### DIFF
--- a/YotiButtonSDK/YotiSDK.swift
+++ b/YotiButtonSDK/YotiSDK.swift
@@ -77,10 +77,12 @@ public class YotiSDK: NSObject {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
 
-        guard let bundleID = options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
-                  bundleID == EnvironmentConfiguation.YotiApp.bundleID
-        else {
-            return false
+        if #available(iOS 13, *) { } else {
+            guard let bundleID = options[UIApplication.OpenURLOptionsKey.sourceApplication] as? String,
+                      bundleID == EnvironmentConfiguation.YotiApp.bundleID
+            else {
+                return false
+            }
         }
 
         var callbackComponents = URLComponents(url: url, resolvingAgainstBaseURL: true)


### PR DESCRIPTION
## Purpose
Remove Yoti App check on iOS 13 due to new privacy policy

## External References (e.g. Jira / Zeplin / Confluence)
https://lampkicking.atlassian.net/browse/YM-16123
https://developer.apple.com/videos/play/wwdc2019/708/

## Approach
Only perform bundle ID check on iOS 12 or below

## Scope of changes
YotiSDK

## Checklist
- [x] You are able to perform a share request successfully on iOS 13

#### Tagged
@lampkicking/ios-dev
