### PR TITLE
Add script phase for compatibility header visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ brew install carthage
 To integrate Yoti into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```
-github "getyoti/ios-sdk-button" ~> 2.0
+github "getyoti/ios-sdk-button" ~> 2.3
 ```
 
 This will allow you to type `carthage update ios-sdk-button` in your Terminal to fetch and build the latest version of the framework.
@@ -62,7 +62,7 @@ $ sudo gem install cocoapods
 To integrate Yoti into your Xcode project using Cocoapods, specify it in your `Podfile`:
 
 ```
-pod 'yoti-sdk' ~> 2.0
+pod 'yoti-sdk' ~> 2.3
 ```
 
 Tip: CocoaPods provides a `pod init` command to create a Podfile with smart defaults. You should use it.

--- a/YotiButtonSDK/Info.plist
+++ b/YotiButtonSDK/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1</string>
+	<string>2.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/yoti-sdk.podspec
+++ b/yoti-sdk.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "yoti-sdk"
-  s.version      = "2.2"
+  s.version      = "2.3"
   s.summary      = "A button SDK that uses Yoti app to complete the share"
 
   # This description is used to generate tags and improve search results.
@@ -134,5 +134,12 @@ Pod::Spec.new do |s|
 
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   # s.dependency "JSONKit", "~> 1.4"
+
+  # ――― Script Phases ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  s.script_phase = {
+    :name => 'Ensure generated compatibility header is visible',
+    :script => 'COMPATIBILITY_HEADER_PATH="${BUILT_PRODUCTS_DIR}/Swift Compatibility Header/${PRODUCT_MODULE_NAME}-Swift.h" && if [ -s "${COMPATIBILITY_HEADER_PATH}" ]; then ditto "${COMPATIBILITY_HEADER_PATH}" "${BUILT_PRODUCTS_DIR}" && ditto "${COMPATIBILITY_HEADER_PATH}" "${PODS_ROOT}/Headers/Public/${PRODUCT_MODULE_NAME}/${PRODUCT_MODULE_NAME}-Swift.h" && ditto "${COMPATIBILITY_HEADER_PATH}" "${PODS_ROOT}/Target Support Files/${PRODUCT_MODULE_NAME}/${PRODUCT_MODULE_NAME}-Swift.h"; fi;',
+    :execution_position => :after_compile
+  }
 
 end


### PR DESCRIPTION
This small script ensures the generated Swift compatibility header (if available) is added to the same locations as the umbrella headers file, which fixes resolution issues in some projects with CocoaPods.

- Bump version.
- Update README to reflect new version.